### PR TITLE
Fixed NPEs in Methods

### DIFF
--- a/paper/src/main/java/com/badbones69/crazyenchantments/Starter.java
+++ b/paper/src/main/java/com/badbones69/crazyenchantments/Starter.java
@@ -77,7 +77,16 @@ public class Starter {
         // Set up all our files.
         fileManager.setLog(true).setup();
 
+        crazyManager = new CrazyManager();
+        // Plugin Support.
+        pluginSupport = new PluginSupport();
+        // Plugin Utils required by methods
+        if (SupportedPlugins.ORAXEN.isPluginLoaded()) oraxenSupport = new OraxenSupport();
+        if (SupportedPlugins.SPARTAN.isPluginLoaded()) spartanSupport = new SpartanSupport();
+
+        // Methods
         methods = new Methods();
+        crazyManager.initMethods();
 
         // Settings.
         protectionCrystalSettings = new ProtectionCrystalSettings();
@@ -102,11 +111,6 @@ public class Starter {
         plugin.pluginManager.registerEvents(scramblerListener = new ScramblerListener(), plugin);
         plugin.pluginManager.registerEvents(scrollListener = new ScrollListener(), plugin);
 
-        crazyManager = new CrazyManager();
-
-        // Plugin Support.
-        pluginSupport = new PluginSupport();
-
         // Plugin Utils.
         bowUtils = new BowUtils();
 
@@ -116,9 +120,7 @@ public class Starter {
 
         if (SupportedPlugins.SUPERIORSKYBLOCK.isPluginLoaded()) superiorSkyBlockSupport = new SuperiorSkyBlockSupport();
 
-        if (SupportedPlugins.ORAXEN.isPluginLoaded()) oraxenSupport = new OraxenSupport();
         if (SupportedPlugins.NO_CHEAT_PLUS.isPluginLoaded()) noCheatPlusSupport = new NoCheatPlusSupport();
-        if (SupportedPlugins.SPARTAN.isPluginLoaded()) spartanSupport = new SpartanSupport();
     }
 
     private final Pattern HEX_PATTERN = Pattern.compile("#[a-fA-F\\d]{6}");

--- a/paper/src/main/java/com/badbones69/crazyenchantments/api/CrazyManager.java
+++ b/paper/src/main/java/com/badbones69/crazyenchantments/api/CrazyManager.java
@@ -41,7 +41,7 @@ public class CrazyManager {
 
     private final Starter starter = plugin.getStarter();
 
-    private final Methods methods = starter.getMethods();
+    private Methods methods;
 
     // Settings.
     private final ProtectionCrystalSettings protectionCrystalSettings = starter.getProtectionCrystalSettings();
@@ -87,6 +87,10 @@ public class CrazyManager {
     private boolean checkVanillaLimit;
 
     private boolean dropBlocksBlast;
+
+    public void initMethods() {
+        methods = starter.getMethods();
+    }
 
     /**
      * Loads everything for the Crazy Enchantments plugin.


### PR DESCRIPTION
_Methods_ calls some _Starter_ methods in order to initialize some final variables.
Said methods return _Starter_ attributes that will be initialized after the _methods_ attribute, therefore returning _null_.
This causes some NPEs (for example when using Oraxen).
To fix that, I've added a method to _CrazyManager_ that has to be called after _Methods_ has been initialized in _Starter_. I've also moved the initialization of all the attributes needed by _Methods_ before it is initialized.
This fixes all the NPEs I've found so far.