### PR TITLE
NPE

### DIFF
--- a/platforms/paper/src/main/java/com/badbones69/crazyenchantments/Starter.java
+++ b/platforms/paper/src/main/java/com/badbones69/crazyenchantments/Starter.java
@@ -74,6 +74,18 @@ public class Starter {
         // Set up all our files.
         this.fileManager.setLog(true).setup();
 
+        // Plugin Support.
+        this.pluginSupport = new PluginSupport();
+
+        this.pluginSupport.initializeWorldGuard();
+
+        if (SupportedPlugins.SUPERIORSKYBLOCK.isPluginLoaded()) this.superiorSkyBlockSupport = new SuperiorSkyBlockSupport();
+
+        if (SupportedPlugins.NO_CHEAT_PLUS.isPluginLoaded()) this.noCheatPlusSupport = new NoCheatPlusSupport();
+
+        if (SupportedPlugins.ORAXEN.isPluginLoaded()) this.oraxenSupport = new OraxenSupport();
+        if (SupportedPlugins.SPARTAN.isPluginLoaded()) this.spartanSupport = new SpartanSupport();
+
         // Methods
         this.methods = new Methods();
 
@@ -101,18 +113,6 @@ public class Starter {
         this.plugin.pluginManager.registerEvents(this.scrollListener = new ScrollListener(), this.plugin);
 
         this.skullCreator = new SkullCreator();
-
-        // Plugin Support.
-        this.pluginSupport = new PluginSupport();
-
-        this.pluginSupport.initializeWorldGuard();
-
-        if (SupportedPlugins.SUPERIORSKYBLOCK.isPluginLoaded()) this.superiorSkyBlockSupport = new SuperiorSkyBlockSupport();
-
-        if (SupportedPlugins.NO_CHEAT_PLUS.isPluginLoaded()) this.noCheatPlusSupport = new NoCheatPlusSupport();
-
-        if (SupportedPlugins.ORAXEN.isPluginLoaded()) this.oraxenSupport = new OraxenSupport();
-        if (SupportedPlugins.SPARTAN.isPluginLoaded()) this.spartanSupport = new SpartanSupport();
 
         this.crazyManager = new CrazyManager();
 

--- a/platforms/paper/src/main/java/com/badbones69/crazyenchantments/enchantments/BowEnchantments.java
+++ b/platforms/paper/src/main/java/com/badbones69/crazyenchantments/enchantments/BowEnchantments.java
@@ -106,7 +106,7 @@ public class BowEnchantments implements Listener {
         EnchantedArrow arrow = bowUtils.enchantedArrow(entityArrow);
 
         // Spawn webs related to STICKY_SHOT.
-        bowUtils.spawnWebs(e.getEntity(), e.getHitEntity(), arrow, entityArrow);
+        bowUtils.spawnWebs(e.getHitEntity(), arrow, entityArrow);
 
         if (CEnchantments.BOOM.isActivated() && arrow != null) {
             if (arrow.hasEnchantment(CEnchantments.BOOM) && CEnchantments.BOOM.chanceSuccessful(arrow.getBow())) {
@@ -193,7 +193,7 @@ public class BowEnchantments implements Listener {
         // Damaged player is an enemy.
         if (!pluginSupport.isFriendly(arrow.getShooter(), entity)) {
 
-            bowUtils.spawnWebs(arrow.getShooter(), e.getEntity(), arrow, entityArrow);
+            bowUtils.spawnWebs(e.getEntity(), arrow, entityArrow);
 
             if (CEnchantments.PULL.isActivated() && arrow.hasEnchantment(CEnchantments.PULL) && CEnchantments.PULL.chanceSuccessful(bow)) {
                 Vector v = arrow.getShooter().getLocation().toVector().subtract(entity.getLocation().toVector()).normalize().multiply(3);

--- a/platforms/paper/src/main/java/com/badbones69/crazyenchantments/utilities/BowUtils.java
+++ b/platforms/paper/src/main/java/com/badbones69/crazyenchantments/utilities/BowUtils.java
@@ -109,26 +109,26 @@ public class BowUtils {
         return webBlocks;
     }
 
-    public void spawnWebs(Entity entity, Entity hitEntity, EnchantedArrow enchantedArrow, Arrow arrow) {
+    public void spawnWebs(Entity hitEntity, EnchantedArrow enchantedArrow, Arrow arrow) {
         if (enchantedArrow == null) return;
 
         if (isBowEnchantActive(CEnchantments.STICKY_SHOT, enchantedArrow, arrow)) {
             if (hitEntity == null) {
-                Location entityLocation = entity.getLocation();
+                Location entityLocation = arrow.getLocation();
 
                 if (entityLocation.getBlock().getType() != Material.AIR) return;
 
                 entityLocation.getBlock().setType(Material.COBWEB);
                 webBlocks.add(entityLocation.getBlock());
 
-                entity.remove();
+                arrow.remove();
 
                 plugin.getServer().getScheduler().runTaskLater(plugin, () -> {
                     entityLocation.getBlock().setType(Material.AIR);
                     webBlocks.remove(entityLocation.getBlock());
                 }, 5 * 20);
             } else {
-                entity.remove();
+                arrow.remove();
                 setWebBlocks(hitEntity);
             }
         }


### PR DESCRIPTION
<h3>Plugin Support</h3>
Fixes the problem that occurs when you have worldguard and worldedit on the server while using specific enchantments which was caused by PluginSupport in Methods being null.

<h3>Sticky Shot</h3>
Fixed the error that occurred due to remove() being called on Player.