### PR TITLE
Rage Boss Bar

### DIFF
--- a/src/main/java/com/badbones69/crazyenchantments/CrazyEnchantments.java
+++ b/src/main/java/com/badbones69/crazyenchantments/CrazyEnchantments.java
@@ -10,12 +10,7 @@ import com.badbones69.crazyenchantments.commands.CETab;
 import com.badbones69.crazyenchantments.commands.GkitzCommand;
 import com.badbones69.crazyenchantments.commands.GkitzTab;
 import com.badbones69.crazyenchantments.commands.TinkerCommand;
-import com.badbones69.crazyenchantments.controllers.BlackSmith;
-import com.badbones69.crazyenchantments.controllers.CommandChecker;
-import com.badbones69.crazyenchantments.controllers.GKitzController;
-import com.badbones69.crazyenchantments.controllers.InfoGUIControl;
-import com.badbones69.crazyenchantments.controllers.LostBookController;
-import com.badbones69.crazyenchantments.controllers.Tinkerer;
+import com.badbones69.crazyenchantments.controllers.*;
 import com.badbones69.crazyenchantments.enchantments.AllyEnchantments;
 import com.badbones69.crazyenchantments.enchantments.ArmorEnchantments;
 import com.badbones69.crazyenchantments.enchantments.AxeEnchantments;
@@ -61,6 +56,8 @@ public class CrazyEnchantments extends JavaPlugin implements Listener {
     private Tinkerer tinkerer;
     private BlackSmith blackSmith;
     private GKitzController gKitzController;
+
+    private final BossBarController bossBarController = new BossBarController(this);
 
     @Override
     public void onEnable() {
@@ -154,6 +151,7 @@ public class CrazyEnchantments extends JavaPlugin implements Listener {
     }
 
     private void disable() {
+        bossBarController.removeAllBossBars();
         armorEnchantments.stop();
 
         if (starter.getAllyManager() != null) starter.getAllyManager().forceRemoveAllies();
@@ -210,5 +208,9 @@ public class CrazyEnchantments extends JavaPlugin implements Listener {
 
     public GKitzController getgKitzController() {
         return this.gKitzController;
+    }
+
+    public BossBarController getBossBarController() {
+        return bossBarController;
     }
 }

--- a/src/main/java/com/badbones69/crazyenchantments/api/CrazyManager.java
+++ b/src/main/java/com/badbones69/crazyenchantments/api/CrazyManager.java
@@ -78,6 +78,7 @@ public class CrazyManager {
     private boolean gkitzToggle;
     private boolean useUnsafeEnchantments;
     private boolean breakRageOnDamage;
+    private boolean useRageBossBar;
     private boolean enchantStackedItems;
     private boolean maxEnchantmentCheck;
     private boolean checkVanillaLimit;
@@ -144,6 +145,7 @@ public class CrazyManager {
         gkitzToggle = !config.contains("Settings.GKitz.Enabled") || config.getBoolean("Settings.GKitz.Enabled");
         rageMaxLevel = config.contains("Settings.EnchantmentOptions.MaxRageLevel") ? config.getInt("Settings.EnchantmentOptions.MaxRageLevel") : 4;
         breakRageOnDamage = !config.contains("Settings.EnchantmentOptions.Break-Rage-On-Damage") || config.getBoolean("Settings.EnchantmentOptions.Break-Rage-On-Damage");
+        useRageBossBar = config.contains("Settings.EnchantmentOptions.Rage-Boss-Bar") && config.getBoolean("Settings.EnchantmentOptions.Rage-Boss-Bar");
         enchantStackedItems = config.contains("Settings.EnchantmentOptions.Enchant-Stacked-Items") && config.getBoolean("Settings.EnchantmentOptions.Enchant-Stacked-Items");
         setDropBlocksBlast(config.getBoolean("Settings.EnchantmentOptions.Drop-Blocks-For-Blast", true));
 
@@ -719,6 +721,13 @@ public class CrazyManager {
      */
     public boolean isBreakRageOnDamageOn() {
         return breakRageOnDamage;
+    }
+
+    /**
+     * @return True if a boss bar will be used to display rage notifications.
+     */
+    public boolean useRageBossBar() {
+        return useRageBossBar;
     }
 
     /**

--- a/src/main/java/com/badbones69/crazyenchantments/controllers/BossBarController.java
+++ b/src/main/java/com/badbones69/crazyenchantments/controllers/BossBarController.java
@@ -1,0 +1,133 @@
+package com.badbones69.crazyenchantments.controllers;
+
+import com.badbones69.crazyenchantments.CrazyEnchantments;
+import com.badbones69.crazyenchantments.utilities.misc.ColorUtils;
+import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.text.Component;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class BossBarController {
+
+    private final HashMap<UUID, BossBar> bossBars;
+    private final CrazyEnchantments plugin;
+
+    public BossBarController(CrazyEnchantments plugin) {
+        this.bossBars = new HashMap<>();
+        this.plugin = plugin;
+    }
+
+    /**
+     *
+     * @param player {@link Player}
+     * @return true if the player currently has a boss bar.
+     */
+    public boolean hasBossBar(Player player) {
+        return bossBars.containsKey(player.getUniqueId());
+    }
+
+    /**
+     *
+     * @param player the {@link Player} whose boss bar you want to get
+     * @return the current boss bar or null.
+     */
+    public BossBar getBossBar(Player player) {
+        return bossBars.get(player.getUniqueId());
+    }
+
+    private void createBossBars(Player player, Component displayText, float progress) {
+        if (hasBossBar(player)) return;
+        BossBar bossBar = BossBar.bossBar(displayText, progress, BossBar.Color.RED, BossBar.Overlay.PROGRESS);
+        bossBars.put(player.getUniqueId(), bossBar);
+        player.showBossBar(bossBar);
+
+        Bukkit.getScheduler().runTaskLater(plugin, () -> { removeBossBar(player); }, 600L);
+
+    }
+
+    /**
+     * Updates the current boss bar or creates a
+     * new one if the player does not have one yet
+     * @param player {@link Player} whose boss bar you want to update
+     * @param text the message that you want to be displayed by the boss bar
+     * @param progress value between 0f and 1f of how much the progress bar should be filled
+     */
+    public void updateBossBar(Player player, Component text, float progress) {
+        if (!hasBossBar(player)) {
+            createBossBars(player, text, progress);
+        } else {
+            bossBars.replace(player.getUniqueId(), getBossBar(player).name(text).progress(progress));
+        }
+        player.showBossBar(getBossBar(player));
+    }
+
+    /**
+     * @see #updateBossBar(Player, Component, float)
+     */
+    public void updateBossBar(Player player, String text, float progress) {
+        updateBossBar(player, ColorUtils.legacyTranslateColourCodes(text), progress);
+    }
+
+    /**
+     * Updates the boss bar repeatedly in order to make it appear smooth.
+     * @param intervals amount of times that the
+     * boss bar is updated to get to the final value
+     * @see #updateBossBar
+     */
+    public void updateBossBarGradually(Player player, String text, float progress, int intervals) {
+        Component newText = ColorUtils.legacyTranslateColourCodes(text);
+        if (!hasBossBar(player)) {
+            createBossBars(player, newText, progress);
+        } else {
+            BossBar bossBar = getBossBar(player).name(newText);
+            float from = bossBar.progress();
+            float difference = (progress - from)/intervals;
+
+            if ((from != progress)) {
+                for (int i = 0; i < intervals; ++i) {
+
+                    from += difference;
+
+                    if (from > 1 || from < 0) break;
+
+                    bossBar.progress(from);
+
+                }
+            }
+
+            bossBar.progress(progress);
+
+            bossBars.replace(player.getUniqueId(), bossBar);
+        }
+        player.showBossBar(getBossBar(player));
+    }
+
+    /**
+     * Removes the players boss bar
+     * @param player the {@link Player} whose boss bar you wish to remove
+     */
+    public void removeBossBar(Player player) {
+        if (!hasBossBar(player)) return;
+        player.hideBossBar(getBossBar(player));
+        bossBars.remove(player.getUniqueId());
+    }
+
+    /**
+     * Deletes all boss bars.
+     */
+    public void removeAllBossBars() {
+
+        if (bossBars.isEmpty()) return;
+
+        for (Map.Entry<UUID, BossBar> entry : bossBars.entrySet()) {
+            Player player = plugin.getServer().getPlayer(entry.getKey());
+            assert player != null;
+            player.hideBossBar(entry.getValue());
+        }
+        bossBars.clear();
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -258,7 +258,7 @@ Settings:
     Enchant-Stacked-Items: false #Turn on if you wish for enchantment books to enchant stacked items.
     MaxRageLevel: 4 #The max amount of rage that scan stack when fighting.
     Break-Rage-On-Damage: true #If the player is damaged while building rage, it will be broken if this is enabled.
-    Rage-Boss-Bar: false; #If true, messages from rage will be displayed on a boss bar.
+    Rage-Boss-Bar: false #If true, messages from rage will be displayed on a boss bar.
     Right-Click-Book-Description: true #Toggles whether when you right-click the enchantment book if it messages the player the description or not.
     UnSafe-Enchantments: true #Having this set to true will allow players to use enchantments levels above the max level.
     Blast-Full-Durability: true #Toggle if the item takes damage for every block it breaks or just one. True to take full damage or false to take only 1 damage.

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -258,6 +258,7 @@ Settings:
     Enchant-Stacked-Items: false #Turn on if you wish for enchantment books to enchant stacked items.
     MaxRageLevel: 4 #The max amount of rage that scan stack when fighting.
     Break-Rage-On-Damage: true #If the player is damaged while building rage, it will be broken if this is enabled.
+    Rage-Boss-Bar: false; #If true, messages from rage will be displayed on a boss bar.
     Right-Click-Book-Description: true #Toggles whether when you right-click the enchantment book if it messages the player the description or not.
     UnSafe-Enchantments: true #Having this set to true will allow players to use enchantments levels above the max level.
     Blast-Full-Durability: true #Toggle if the item takes damage for every block it breaks or just one. True to take full damage or false to take only 1 damage.


### PR DESCRIPTION
Add a config option to change rage over to using a boss bar to inform players instead of using chat.
Boss-Bar will vanish after 30 seconds.
Config option: `Rage-Boss-Bar: false`