### PR TITLE
Add overrides for CE Books

### DIFF
--- a/paper/src/main/java/com/badbones69/crazyenchantments/paper/CrazyEnchantments.java
+++ b/paper/src/main/java/com/badbones69/crazyenchantments/paper/CrazyEnchantments.java
@@ -61,6 +61,18 @@ public class CrazyEnchantments extends JavaPlugin {
         FileConfiguration config = Files.CONFIG.getFile();
         FileConfiguration tinker = Files.TINKER.getFile();
 
+        if (!config.contains("Settings.CESuccessOverride")) {
+            config.set("Settings.CESuccessOverride", "-1");
+
+            Files.CONFIG.saveFile();
+        }
+
+        if (!config.contains("Settings.CESuccessOverride")) {
+            config.set("Settings.CEFailureOverride", "-1");
+
+            Files.CONFIG.saveFile();
+        }
+
         if (!config.contains("Settings.Toggle-Metrics")) {
             config.set("Settings.Toggle-Metrics", false);
 

--- a/paper/src/main/java/com/badbones69/crazyenchantments/paper/api/CrazyManager.java
+++ b/paper/src/main/java/com/badbones69/crazyenchantments/paper/api/CrazyManager.java
@@ -128,6 +128,9 @@ public class CrazyManager {
     private int defaultBaseLimit;
     private boolean checkLimitPermission;
 
+    private int CESuccessOverride;
+    private int CEFailureOverride;
+
     /**
      * Loads everything for the Crazy Enchantments plugin.
      * Do not use unless needed.
@@ -205,6 +208,9 @@ public class CrazyManager {
         this.rageIncrement = config.getDouble("Settings.EnchantmentOptions.Rage-Increase", 0.1);
         setDropBlocksBlast(config.getBoolean("Settings.EnchantmentOptions.Drop-Blocks-For-Blast", true));
         setDropBlocksVeinMiner(config.getBoolean("Settings.EnchantmentOptions.Drop-Blocks-For-VeinMiner", true));
+
+        this.CEFailureOverride = config.getInt("Settings.CEFailureOverride", -1);
+        this.CESuccessOverride = config.getInt("Settings.CESuccessOverride", -1);
 
         this.enchantmentBookSettings.populateMaps();
 
@@ -948,4 +954,11 @@ public class CrazyManager {
     public int pickLevel(int min, int max) {
         return min + new Random().nextInt((max + 1) - min);
     }
+
+    /** Gets the success override from the config. Default -1 means no override should be used */
+    public int getCESuccessOverride() { return CESuccessOverride; }
+
+    /** Gets the failure override from the config. Default -1 means no override should be used */
+    public int getCEFailureOverride() { return CEFailureOverride; }
+
 }

--- a/paper/src/main/java/com/badbones69/crazyenchantments/paper/api/objects/CEBook.java
+++ b/paper/src/main/java/com/badbones69/crazyenchantments/paper/api/objects/CEBook.java
@@ -187,10 +187,10 @@ public class CEBook {
     
     /**
      * Get the destroy rate on the book.
-     * @return Destroy rate of the book.
+     * @return Destroy rate of the book or the override value if set in config.yml
      */
     public int getDestroyRate() {
-        return this.destroyRate;
+        return this.starter.getCrazyManager().getCEFailureOverride() == -1 ? this.destroyRate : this.starter.getCrazyManager().getCEFailureOverride();
     }
     
     /**
@@ -204,10 +204,10 @@ public class CEBook {
     
     /**
      * Get the success rate on the book.
-     * @return The success rate of the book.
+     * @return The success rate of the book or the override value if set in config.yml.
      */
     public int getSuccessRate() {
-        return this.successRate;
+        return this.starter.getCrazyManager().getCESuccessOverride() == -1 ? this.successRate : this.starter.getCrazyManager().getCESuccessOverride();
     }
     
     /**

--- a/paper/src/main/resources/config.yml
+++ b/paper/src/main/resources/config.yml
@@ -13,6 +13,8 @@ Settings:
   Enchantment-Book-Item: 'BOOK' #The item that the enchantment book is.
   Enchantment-Book-Glowing: true #Toggle on or off if the book will have an enchanted look.
   GUISize: 54 #The size of the GUI, must be a factor of 9
+  CESuccessOverride: -1 #0-100, -1 for no override. Chance of success using a CE Book
+  CEFailureOverride: -1 #0-100, -1 for no override. Chance of destroying a CE Book
   EnchantmentBookLore: #The lore on the enchantments books.
     - '&7Drag book and drop on Item.'
     - '&7Right click for more Info.'


### PR DESCRIPTION
Overrides set in config.yml allowing server admins to set override values for the success and destroy chances for a CE Book. If set (default is existing functionality) then any calculated value is ignored and this value is used.