### PR TITLE
Fix Gkit Preview

### DIFF
--- a/paper/src/main/java/com/badbones69/crazyenchantments/paper/api/builders/types/gkitz/KitsMenu.java
+++ b/paper/src/main/java/com/badbones69/crazyenchantments/paper/api/builders/types/gkitz/KitsMenu.java
@@ -132,8 +132,9 @@ public class KitsMenu extends InventoryBuilder {
             GKitz kit = this.crazyManager.getGKitFromName(nbtItem.getString("gkit"));
 
             if (event.getAction() == InventoryAction.PICKUP_HALF) {
-                List<ItemStack> items = kit.getPreviewItems();
-                int slots = Math.min(((items.size() / 9) + (items.size() % 9 > 0 ? 1 : 0)) * 9, 54);
+
+                int amountOfItems = kit.getPreviewItems().size() + 1; // Add 1 to account for the back button.
+                int slots = Math.min(((amountOfItems / 9) + (amountOfItems % 9 > 0 ? 1 : 0)) * 9, 54);
 
                 MenuManager.openKitsPreviewMenu(player, slots, kit);
 

--- a/paper/src/main/java/com/badbones69/crazyenchantments/paper/api/builders/types/gkitz/KitsPreviewMenu.java
+++ b/paper/src/main/java/com/badbones69/crazyenchantments/paper/api/builders/types/gkitz/KitsPreviewMenu.java
@@ -3,8 +3,7 @@ package com.badbones69.crazyenchantments.paper.api.builders.types.gkitz;
 import com.badbones69.crazyenchantments.paper.api.builders.InventoryBuilder;
 import com.badbones69.crazyenchantments.paper.api.objects.gkitz.GKitz;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.ItemStack;
-import java.util.List;
+import org.bukkit.inventory.Inventory;
 
 public class KitsPreviewMenu extends InventoryBuilder {
 
@@ -14,14 +13,11 @@ public class KitsPreviewMenu extends InventoryBuilder {
 
     @Override
     public InventoryBuilder build() {
-        for (ItemStack itemStack : getKit().getPreviewItems()) {
-            getInventory().addItem(itemStack);
-        }
+        Inventory inv = getInventory();
 
-        List<ItemStack> items = getKit().getPreviewItems();
-        int slots = Math.min(((items.size() / 9) + (items.size() % 9 > 0 ? 1 : 0)) * 9, 54);
+        getKit().getPreviewItems().forEach(inv::addItem);
 
-        getInventory().setItem(slots - 1, KitsManager.getBackRight());
+        inv.setItem(inv.getSize() - 1, KitsManager.getBackRight());
 
         return this;
     }


### PR DESCRIPTION
- Make fake items show up in the Gkit preview.
- Take the back button into account when creating the inventory size.