### PR TITLE
Allow Block Interaction

### DIFF
--- a/paper/src/main/java/com/badbones69/crazyenchantments/paper/controllers/EnchantmentControl.java
+++ b/paper/src/main/java/com/badbones69/crazyenchantments/paper/controllers/EnchantmentControl.java
@@ -17,6 +17,7 @@ import com.badbones69.crazyenchantments.paper.controllers.settings.EnchantmentBo
 import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
@@ -173,6 +174,7 @@ public class EnchantmentControl implements Listener {
     @EventHandler
     public void onDescriptionSend(PlayerInteractEvent event) {
         if (event.getHand() != EquipmentSlot.HAND) return;
+        if (event.useInteractedBlock().equals(Event.Result.ALLOW)) return;
 
         if ((event.getAction() == Action.RIGHT_CLICK_BLOCK || event.getAction() == Action.RIGHT_CLICK_AIR) && Files.CONFIG.getFile().getBoolean("Settings.EnchantmentOptions.Right-Click-Book-Description")) {
             ItemStack item = methods.getItemInHand(event.getPlayer());


### PR DESCRIPTION
- If the player clicks an interactable block with a CE item, it will no longer display the information of said CE item.
- Lets players place enchanted books into chiselled bookshelves.