### PR TITLE
Improve Limit Info

### DIFF
--- a/paper/src/main/java/com/badbones69/crazyenchantments/paper/api/enums/Messages.java
+++ b/paper/src/main/java/com/badbones69/crazyenchantments/paper/api/enums/Messages.java
@@ -88,6 +88,7 @@ public enum Messages {
     "&7Base Enchantment Limit: &6%baseLimit%",
     "&7Current Items Slot Crystal Limit Adjustment: &6%slotCrystal%",
     "&7Current Enchantment amount on item: &6%item%",
+    "&7This item can have &6%canHave% &7enchants.",
     "&7You can add &6%space% &7more enchantments to this item.",
     "&c&cLimit set in config.yml: %limitSetInConfig%",
     "&0======================================")),

--- a/paper/src/main/java/com/badbones69/crazyenchantments/paper/commands/CECommand.java
+++ b/paper/src/main/java/com/badbones69/crazyenchantments/paper/commands/CECommand.java
@@ -209,15 +209,17 @@ public class CECommand implements CommandExecutor {
                     int limit = this.crazyManager.getPlayerMaxEnchantments(player);
                     int baseLimit = this.crazyManager.getPlayerBaseEnchantments(player);
                     int slotModifier = item.isEmpty() ? 0 : this.crazyManager.getEnchantmentLimiter(item);
+                    int enchantAmount = item.isEmpty() ? 0 : this.enchantmentBookSettings.getEnchantmentAmount(item, this.crazyManager.checkVanillaLimit());
 
                     int canAdd = Math.min(baseLimit - slotModifier, limit);
 
                     placeholders.put("%limit%", String.valueOf(limit));
                     placeholders.put("%baseLimit%", String.valueOf(baseLimit));
                     placeholders.put("%vanilla%", String.valueOf(this.crazyManager.checkVanillaLimit()));
-                    placeholders.put("%item%", String.valueOf(item.isEmpty() ? 0 : this.enchantmentBookSettings.getEnchantmentAmount(item, this.crazyManager.checkVanillaLimit())));
+                    placeholders.put("%item%", String.valueOf(enchantAmount));
                     placeholders.put("%slotCrystal%", String.valueOf(-slotModifier));
-                    placeholders.put("%space%", String.valueOf(canAdd));
+                    placeholders.put("%space%", String.valueOf(canAdd - enchantAmount));
+                    placeholders.put("%canHave%", String.valueOf(canAdd));
                     placeholders.put("%limitSetInConfig%", String.valueOf(this.crazyManager.useConfigLimit()));
 
                     sender.sendMessage(Messages.LIMIT_COMMAND.getMessage(placeholders));

--- a/paper/src/main/resources/Messages.yml
+++ b/paper/src/main/resources/Messages.yml
@@ -77,6 +77,7 @@ Messages:
     - '&7Base Enchantment Limit: &6%baseLimit%'
     - '&7Current Items Slot Crystal Limit Adjustment: &6%slotCrystal%'
     - '&7Current Enchantment amount on item: &6%item%'
+    - "&7This item can have &6%canHave% &7enchants."
     - '&7You can add &6%space% &7more enchantments to this item.'
     - '&cLimit set in config.yml: %limitSetInConfig%'
     - '&0======================================'


### PR DESCRIPTION
Change the value from how many enchants can be on the item, to instead being the amount that a player can still add onto the item.