### PR TITLE
armorchangeevent error and dust fix

### DIFF
--- a/paper/src/main/java/com/badbones69/crazyenchantments/paper/enchantments/ArmorEnchantments.java
+++ b/paper/src/main/java/com/badbones69/crazyenchantments/paper/enchantments/ArmorEnchantments.java
@@ -170,7 +170,15 @@ public class ArmorEnchantments implements Listener {
         HashMap<PotionEffectType, Integer> topPotions = new HashMap<>();
 
         topEnchants.forEach((key, value) -> enchantmentPotions.entrySet()
-                .stream().filter(enchantedPotion -> enchantedPotion.getKey().getEnchantment().equals(key))
+                .stream().filter(enchantedPotion -> {
+                    // What is fixed: removing an enchantment from the yml would normally make this armorchangeevent throw a massive error every 1s
+                    // Code tested and verified to work (tested on 1.21.4 folia server) and doesn't show errors anymore
+                    CEnchantment enchantment = enchantedPotion.getKey().getEnchantment();
+                    return Objects.equals(enchantment, key); // This fix makes it so if getEnchantment returns null it doesn't try to use null.equals(key)
+                    /*Used to be:
+                     * .stream().filter(enchantedPotion -> enchantedPotion.getKey().getEnchantment().equals(key))
+                     */
+                })
                 .forEach(enchantedPotion -> enchantedPotion.getValue().entrySet().stream()
                         .filter(pot -> !topPotions.containsKey(pot.getKey()) || (topPotions.get(pot.getKey()) != -1 && topPotions.get(pot.getKey()) <= pot.getValue()))
                         .forEach(pot -> topPotions.put(pot.getKey(), value))));

--- a/paper/src/main/java/com/badbones69/crazyenchantments/paper/listeners/DustControlListener.java
+++ b/paper/src/main/java/com/badbones69/crazyenchantments/paper/listeners/DustControlListener.java
@@ -89,10 +89,17 @@ public class DustControlListener implements Listener {
 
         if (book.getAmount() > 1) return;
 
-        final PersistentDataContainerView container = dust.getPersistentDataContainer();
+        // this new and updated code will make it parse 'bookData' as the currentItem, and 'dustData' as the cursor item.
+        // Before, it always incorrectly compared bookData and dustData to null as both were created using the same item!
+        // And a single item cannot be both a book and both dust, so one is bound to be null.
+        // However with my commit it will compare the 2 different datacontainer items. -- This code has been tested and is what made the dust work for me finally (tested on 1.21.4 folia server)
 
-        final DustData dustData = Methods.getGson().fromJson(container.get(DataKeys.dust.getNamespacedKey(), PersistentDataType.STRING), DustData.class);
-        final EnchantedBook bookData = Methods.getGson().fromJson(container.get(DataKeys.stored_enchantments.getNamespacedKey(), PersistentDataType.STRING), EnchantedBook.class); //Once Books have PDC
+        final PersistentDataContainerView dust_container = dust.getPersistentDataContainer(); // var renamed
+        final PersistentDataContainerView book_container = book.getPersistentDataContainer(); // line added
+        
+        // changed container vars of both lines
+        final DustData dustData = Methods.getGson().fromJson(dust_container.get(DataKeys.dust.getNamespacedKey(), PersistentDataType.STRING), DustData.class);
+        final EnchantedBook bookData = Methods.getGson().fromJson(book_container.get(DataKeys.stored_enchantments.getNamespacedKey(), PersistentDataType.STRING), EnchantedBook.class); //Once Books have PDC
 
         if (bookData == null || dustData == null) return;
 


### PR DESCRIPTION
Armor fix: removing an enchantment from the yml would normally make this armorchangeevent throw a massive error every 1s -- now doesn't give errors anymore

Dust fix: Magical Dust (Angel/Fixing) previously always returned early as it wrongfully compared item-data. This made you not able to apply the dust on a book. I'm assuming the official jar did not use the latest github version? Well now it is fixed
// this new and updated code will make it parse 'bookData' as the currentItem, and 'dustData' as the cursor item.
// Before, it always incorrectly compared bookData and dustData to null as both were created using the same item!
// And a single item cannot be both a book and both dust, so one is bound to be null.
// However with my commit it will compare the 2 different datacontainer items. 

Please read my code comments for more info