### PR TITLE
Fix Enchant Effects

### DIFF
--- a/paper/src/main/java/com/badbones69/crazyenchantments/paper/enchantments/ArmorEnchantments.java
+++ b/paper/src/main/java/com/badbones69/crazyenchantments/paper/enchantments/ArmorEnchantments.java
@@ -109,6 +109,8 @@ public class ArmorEnchantments implements Listener {
         final NamespacedKey key = DataKeys.enchantments.getNamespacedKey();
 
         event.getEquipmentChanges().forEach((slot, action) -> {
+            if (slot.isHand()) return;
+
             final ItemStack newItem = action.newItem();
             final ItemStack oldItem = action.oldItem();
 


### PR DESCRIPTION
## What's Changed:
- Fix effects not properly being removed when players remove their equipped items. #907 
- Fix effects being activated when the item is in a player's hand. #909 
  - This seems to have been caused by the event being updated between versions by upstream.