### PR TITLE
Compile against 1.21.8 instead of 1.21.10 to support Folia

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 crazyenchantments = "2.6.3"
 
 # Minecraft
-minecraft = "1.21.10"
+minecraft = "1.21.8"
 
 ## JetBrains
 annotations = "24.1.0" # https://github.com/JetBrains/java-annotations
@@ -24,7 +24,7 @@ bStats = "3.1.0" # https://github.com/Bastian/bStats
 
 ## Paper
 paperweight = "2.0.0-beta.19" # https://github.com/PaperMC/paperweight
-paper = "1.21.10-R0.1-SNAPSHOT" # https://github.com/PaperMC/Paper
+paper = "1.21.8-R0.1-SNAPSHOT" # https://github.com/PaperMC/Paper
 
 ## Gradle Plugins
 fix-javadoc = "1.19" # https://github.com/mfnalex/gradle-fix-javadoc-plugin


### PR DESCRIPTION
Folia still doesn't support 1.21.10, and some mostly crucial fixes were made in recent versions of CrazyEnchantments that are inaccessible on Folia unless 1.21.10 is downgraded to 1.21.8. Until Folia 1.21.10 (or later) is released, it's best to support 1.21.8 for the time being, especially since it doesn't appear to interfere with much when testing against both versions.